### PR TITLE
add a parameter to specify an SMTP port number to override default

### DIFF
--- a/src/main/java/org/ccci/util/mail/MailMessageFactory.java
+++ b/src/main/java/org/ccci/util/mail/MailMessageFactory.java
@@ -58,9 +58,6 @@ public class MailMessageFactory
 		this.mailSession = getSession(props, passwordAuthentication);
 	}
 
-	/**
-	 * Builds a properties file instance with smtp as the protocol and the host specified in @param smtpHost as the host.
-	 */
 	private Properties buildPropertiesWithProtocolAndHost(String smtpHost)
 	{
 		Properties props = new Properties();


### PR DESCRIPTION
background:
- Amazon (may be) throttling traffic on port 25 with their SES leading to connection timeouts for ERT
- They advertise other ports which are not throttled, but specifying a parameter is required to use them
