### PR TITLE
UTF-8 encode subject

### DIFF
--- a/src/test/java/org/ccci/util/mail/EmailAddressTest.java
+++ b/src/test/java/org/ccci/util/mail/EmailAddressTest.java
@@ -53,7 +53,6 @@ public class EmailAddressTest
                 new MailMessageFactory(mailServer, mailServerPort, passwordAuthentication);
 
         MailMessage mailMessage = mailMessageFactory.createApplicationMessage();
-
         mailMessage.setFrom(fromEmailAddress, "Local Util Test Run");
         mailMessage.addTo(toEmailAddress);
         mailMessage.setReplyTo(replyToEmailAddress, name);


### PR DESCRIPTION
Tested, works.

Will deploy to JFrog as util v. 9
Will deploy as a release, not snapshot as that appears to be the standard practice since v. 5

To be leveraged initially by https://github.com/CruGlobal/ert-api/pull/1000.