### PR TITLE
Use existing partition method for getPersonalEmailAddressesForIds()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ transaction.log
 
 .idea
 *.iml
+.DS_Store
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.ccci</groupId>
   <artifactId>util</artifactId>
   <packaging>jar</packaging>
-  <version>9.6</version>
+  <version>9.7</version>
   <name>util</name>
 
   <scm>

--- a/src/main/java/org/ccci/dao/psdb/EmployeeDAOImpl.java
+++ b/src/main/java/org/ccci/dao/psdb/EmployeeDAOImpl.java
@@ -272,27 +272,32 @@ public class EmployeeDAOImpl implements EmployeeDAO
             return Sets.newHashSet();
         }
 
-        List<Object[]> rawEmailAddresses = Generics.checkObjectArrayList( 
-            psEntityManager.createNamedQuery("EmployeeEntity.findEmailInfoByEmployeeIds")
-            .setParameter("employeeIds", employeeIds)
-            .getResultList(), 
-            String.class, String.class, String.class);
-
-        Set<PersonalEmailAddress> personalEmailAddresses = Sets.newHashSetWithExpectedSize(rawEmailAddresses.size());
-        for (Object[] row : rawEmailAddresses)
+        List<List<EmployeeId>> partitions = partition(employeeIds);
+        Set<PersonalEmailAddress> allPersonalEmailAddresses = Sets.newHashSet();
+        
+        for (List<EmployeeId> partition : partitions)
         {
-            String personalName = row[0] + " " + row[1];
-            String emailAddress = (String) row[2];
-            try
+            List<Object[]> rawEmailAddresses = Generics.checkObjectArrayList( 
+                psEntityManager.createNamedQuery("EmployeeEntity.findEmailInfoByEmployeeIds")
+                .setParameter("employeeIds", partition)
+                .getResultList(), 
+                String.class, String.class, String.class);
+
+            for (Object[] row : rawEmailAddresses)
             {
-                personalEmailAddresses.add(PersonalEmailAddress.newPersonalEmailAddress(emailAddress, personalName));
-            }
-            catch (IllegalArgumentException e)
-            {
-                log.warn(String.format("employee %s has an invalid email address: %s", personalName, emailAddress));
+                String personalName = row[0] + " " + row[1];
+                String emailAddress = (String) row[2];
+                try
+                {
+                    allPersonalEmailAddresses.add(PersonalEmailAddress.newPersonalEmailAddress(emailAddress, personalName));
+                }
+                catch (IllegalArgumentException e)
+                {
+                    log.warn(String.format("employee %s has an invalid email address: %s", personalName, emailAddress));
+                }
             }
         }
-        return personalEmailAddresses;
+        return allPersonalEmailAddresses;
 	}
 
     @Override

--- a/src/main/java/org/ccci/dao/psdb/EmployeeDAOImpl.java
+++ b/src/main/java/org/ccci/dao/psdb/EmployeeDAOImpl.java
@@ -170,7 +170,7 @@ public class EmployeeDAOImpl implements EmployeeDAO
         return query;
     }
 
-    private List<List<EmployeeId>> partition(final Set<EmployeeId> employeeIds)
+    List<List<EmployeeId>> partition(final Set<EmployeeId> employeeIds)
     {
         Iterable<List<EmployeeId>> partitionAsIterable = Iterables.partition(employeeIds, partitionSize);
         List<List<EmployeeId>> partition = Lists.newArrayList();

--- a/src/test/java/org/ccci/dao/psdb/EmployeeDAOImplTest.java
+++ b/src/test/java/org/ccci/dao/psdb/EmployeeDAOImplTest.java
@@ -276,7 +276,16 @@ public class EmployeeDAOImplTest
     {
         employeeDAO.getPersonalEmailAddressesForIds(null);
     }
-    
+
+    // Helper method for creating test employees with specific employment status
+    private EmployeeEntity createEmployeeWithStatus(EmployeeId employeeId, String firstName, String lastName,
+                                                    String email, String employmentStatus)
+    {
+        EmployeeEntity employee = createEmployee(employeeId, firstName, lastName, email);
+        employee.setEmploymentStatus(employmentStatus);
+        return employee;
+    }
+
     // Helper method for creating test employees - no employment status set automatically
     private EmployeeEntity createEmployee(EmployeeId employeeId, String firstName, String lastName, String email)
     {
@@ -288,15 +297,6 @@ public class EmployeeDAOImplTest
             employee.setEmail(EmailAddress.valueOf(email));
         }
         entityManager.persist(employee);
-        return employee;
-    }
-
-    // Helper method for creating test employees with specific employment status
-    private EmployeeEntity createEmployeeWithStatus(EmployeeId employeeId, String firstName, String lastName,
-                                                    String email, String employmentStatus)
-    {
-        EmployeeEntity employee = createEmployee(employeeId, firstName, lastName, email);
-        employee.setEmploymentStatus(employmentStatus);
         return employee;
     }
     

--- a/src/test/java/org/ccci/dao/psdb/EmployeeDAOImplTest.java
+++ b/src/test/java/org/ccci/dao/psdb/EmployeeDAOImplTest.java
@@ -29,6 +29,12 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import com.google.common.collect.Lists;
+import org.ccci.util.mail.PersonalEmailAddress;
+import com.google.common.base.Preconditions;
+import org.ccci.util.Generics;
+
+import java.util.Set;
 
 @PersistenceUnitBuiltBy(HibernateInMemoryH2PersistenceUnitFactory.class)
 public class EmployeeDAOImplTest
@@ -252,6 +258,105 @@ public class EmployeeDAOImplTest
     }
     
     @Test
+    public void testGetPersonalEmailAddressesForIds_straightforward()
+    {
+        createEmployeeWithEmail(employeeId1, "Joe", "Staff", "joe.staff@cru.org");
+        createEmployeeWithEmail(employeeId2, "Sam", "Intern", "sam.intern@cru.org");
+
+        Set<PersonalEmailAddress> emailAddresses = employeeDAO.getPersonalEmailAddressesForIds(
+            Sets.newHashSet(employeeId1, employeeId2));
+        
+        Assert.assertEquals(2, emailAddresses.size());
+        assertContainsEmail(emailAddresses, "joe.staff@cru.org", "Joe Staff", "Expected to find Joe's email address");
+        assertContainsEmail(emailAddresses, "sam.intern@cru.org", "Sam Intern", "Expected to find Sam's email address");
+    }
+    
+    @Test
+    public void testGetPersonalEmailAddressesForIds_filtersEmptyEmails()
+    {
+        createEmployeeWithEmail(employeeId1, "Joe", "Staff", "joe.staff@cru.org");
+        createEmployeeWithoutEmail(employeeId2, "Sam", "Intern"); // No email - should be filtered out
+
+        Set<PersonalEmailAddress> emailAddresses = employeeDAO.getPersonalEmailAddressesForIds(
+            Sets.newHashSet(employeeId1, employeeId2));
+        
+        // Should only get Joe's email since Sam has no email
+        Assert.assertEquals(1, emailAddresses.size());
+        PersonalEmailAddress email = Iterables.getOnlyElement(emailAddresses);
+        Assert.assertEquals("joe.staff@cru.org", email.getEmailAddress().toString());
+        Assert.assertEquals("Joe Staff", email.getPersonalName());
+    }
+    
+    /**
+     * Test that the chunking functionality works correctly when partition size exceeds Oracle's 1000-element IN clause limit.
+     * This test specifically addresses the issue that was causing reminder email failures.
+     */
+    @Test
+    public void testGetPersonalEmailAddressesForIds_chunking()
+    {
+        // Create a query-counting DAO for this test
+        QueryCountingEmployeeDAO queryCountingDAO = new QueryCountingEmployeeDAO();
+        queryCountingDAO.psEntityManager = entityManager;
+        queryCountingDAO.setPartitionSize(2);
+        
+        createEmployeeWithEmail(employeeId1, "Joe", "Staff", "joe.staff@cru.org");
+        createEmployeeWithEmail(employeeId2, "Sam", "Intern", "sam.intern@cru.org");
+        createEmployeeWithEmail(employeeId3, "Jane", "Manager", "jane.manager@cru.org");
+
+        // This will be split into chunks: [employee1, employee2] and [employee3]
+        Set<PersonalEmailAddress> emailAddresses = queryCountingDAO.getPersonalEmailAddressesForIds(
+            Sets.newHashSet(employeeId1, employeeId2, employeeId3));
+        
+        Assert.assertEquals(3, emailAddresses.size());
+        
+        // Verify all employees are found despite chunking
+        assertContainsEmail(emailAddresses, "joe.staff@cru.org", "Joe Staff", "Expected to find Joe's email from first chunk");
+        assertContainsEmail(emailAddresses, "sam.intern@cru.org", "Sam Intern", "Expected to find Sam's email from first chunk");
+        assertContainsEmail(emailAddresses, "jane.manager@cru.org", "Jane Manager", "Expected to find Jane's email from second chunk");
+        
+        // Verify that exactly 2 queries were executed (one for each chunk)
+        Assert.assertEquals("Expected 2 queries to be executed due to chunking", 2, queryCountingDAO.getNamedQueryExecutionCount());
+    }
+    
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testGetPersonalEmailAddressesForIds_nullInput()
+    {
+        employeeDAO.getPersonalEmailAddressesForIds(null);
+    }
+    
+    // Helper methods for creating test employees
+    private EmployeeEntity createEmployeeWithEmail(EmployeeId employeeId, String firstName, String lastName, String email)
+    {
+        EmployeeEntity employee = new EmployeeEntity();
+        employee.setKey(new EmployeeEntity.Key(employeeId, 0));
+        employee.setFirstName(firstName);
+        employee.setLastName(lastName);
+        if (email != null) {
+            employee.setEmail(EmailAddress.valueOf(email));
+        }
+        entityManager.persist(employee);
+        return employee;
+    }
+    
+    private void createEmployeeWithoutEmail(EmployeeId employeeId, String firstName, String lastName)
+    {
+        createEmployeeWithEmail(employeeId, firstName, lastName, null);
+    }
+    
+    // Helper method for verifying email addresses in results
+    private void assertContainsEmail(Set<PersonalEmailAddress> emailAddresses, String expectedEmail, String expectedName, String description)
+    {
+        boolean found = false;
+        for (PersonalEmailAddress email : emailAddresses) {
+            if (email.getEmailAddress().toString().equals(expectedEmail) && email.getPersonalName().equals(expectedName)) {
+                found = true;
+                break;
+            }
+        }
+        Assert.assertTrue(description, found);
+    }
+    
+    @Test
     public void testFindEmployeeUnit_single()
     {
         EmployeeEntity employee = new EmployeeEntity();
@@ -336,5 +441,68 @@ public class EmployeeDAOImplTest
         Assert.assertEquals(employeeId3, couple.getSecondary().getEmployeeId());
         Assert.assertEquals(employeeId1, couple.getHusband().getEmployeeId());
         Assert.assertEquals(employeeId3, couple.getWife().getEmployeeId());
+    }
+    
+    /**
+     * Test helper class that extends EmployeeDAOImpl to count query executions for testing chunking behavior.
+     */
+    private static class QueryCountingEmployeeDAO extends EmployeeDAOImpl {
+        private int namedQueryExecutionCount = 0;
+        
+        public QueryCountingEmployeeDAO() {
+            super();
+        }
+        
+        @Override
+        public Set<PersonalEmailAddress> getPersonalEmailAddressesForIds(Set<EmployeeId> employeeIds) {
+            Preconditions.checkNotNull(employeeIds, "employeeIds is null");
+            if (employeeIds.isEmpty())
+            {
+                return Sets.newHashSet();
+            }
+
+            // Create partitions manually since the method is private
+            List<List<EmployeeId>> partitions = Lists.newArrayList();
+            Iterable<List<EmployeeId>> partitionAsIterable = Iterables.partition(employeeIds, getPartitionSize());
+            for (Iterable<EmployeeId> partAsIterable : partitionAsIterable)
+            {
+                List<EmployeeId> part = Lists.newArrayList(partAsIterable);
+                partitions.add(part);
+            }
+            
+            Set<PersonalEmailAddress> allPersonalEmailAddresses = Sets.newHashSet();
+            
+            // Count each partition as a separate query execution
+            for (List<EmployeeId> partition : partitions)
+            {
+                namedQueryExecutionCount++; // Count the query execution
+                
+                List<Object[]> rawEmailAddresses = Generics.checkObjectArrayList( 
+                    psEntityManager.createNamedQuery("EmployeeEntity.findEmailInfoByEmployeeIds")
+                    .setParameter("employeeIds", partition)
+                    .getResultList(), 
+                    String.class, String.class, String.class);
+
+                for (Object[] row : rawEmailAddresses)
+                {
+                    String personalName = row[0] + " " + row[1];
+                    String emailAddress = (String) row[2];
+                    try
+                    {
+                        allPersonalEmailAddresses.add(PersonalEmailAddress.newPersonalEmailAddress(emailAddress, personalName));
+                    }
+                    catch (IllegalArgumentException e)
+                    {
+                        log.warn(String.format("employee %s has an invalid email address: %s", personalName, emailAddress));
+                    }
+                }
+            }
+            
+            return allPersonalEmailAddresses;
+        }
+        
+        public int getNamedQueryExecutionCount() {
+            return namedQueryExecutionCount;
+        }
     }
 }

--- a/src/test/java/org/ccci/dao/psdb/EmployeeDAOImplTest.java
+++ b/src/test/java/org/ccci/dao/psdb/EmployeeDAOImplTest.java
@@ -29,10 +29,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
-import com.google.common.collect.Lists;
 import org.ccci.util.mail.PersonalEmailAddress;
-import com.google.common.base.Preconditions;
-import org.ccci.util.Generics;
 
 import java.util.Set;
 
@@ -131,19 +128,8 @@ public class EmployeeDAOImplTest
     @Test
     public void testSearchByNameOrEmplid_resultsLimited()
     {
-        EmployeeEntity employee1 = new EmployeeEntity();
-        employee1.setKey(new EmployeeEntity.Key(employeeId1, 0));
-        employee1.setFirstName("Joe");
-        employee1.setLastName("Staff");
-        employee1.setEmploymentStatus(EmploymentStatus.ACTIVE);
-        entityManager.persist(employee1);
-
-        EmployeeEntity employee2 = new EmployeeEntity();
-        employee2.setKey(new EmployeeEntity.Key(employeeId2, 0));
-        employee2.setFirstName("Sam");
-        employee2.setLastName("Staff");
-        employee1.setEmploymentStatus(EmploymentStatus.ACTIVE);
-        entityManager.persist(employee2);
+        createEmployeeWithStatus(employeeId1, "Joe", "Staff", null, EmploymentStatus.ACTIVE);
+        createEmployeeWithStatus(employeeId2, "Sam", "Staff", null, EmploymentStatus.ACTIVE);
 
         List<Employee> employeesFound = employeeDAO.searchByNameEmailOrEmployeeId("Staff", 1);
         Assert.assertEquals("Staff", Iterables.getOnlyElement(employeesFound).getLastName());
@@ -152,23 +138,13 @@ public class EmployeeDAOImplTest
     @Test
     public void testSearchByNameOrEmplid_findCorrectEmployee()
     {
-        EmployeeEntity employee1 = new EmployeeEntity();
-        employee1.setKey(new EmployeeEntity.Key(employeeId1, 0));
-        employee1.setFirstName("Joseph");
+        EmployeeEntity employee1 = createEmployeeWithStatus(employeeId1, "Joseph", "Staff",
+                "joe.staff@ccci.org", EmploymentStatus.ACTIVE);
         employee1.setPreferredFirstName("Joe");
-        employee1.setLastName("Staff");
-        employee1.setEmail(EmailAddress.valueOf("joe.staff@ccci.org"));
-        employee1.setEmploymentStatus(EmploymentStatus.ACTIVE);
-        entityManager.persist(employee1);
 
-        EmployeeEntity employee2 = new EmployeeEntity();
-        employee2.setKey(new EmployeeEntity.Key(employeeId2, 0));
-        employee2.setFirstName("Samuel");
+        EmployeeEntity employee2 = createEmployeeWithStatus(employeeId2, "Samuel", "Intern",
+                "sam.intern@uscm.org", EmploymentStatus.ACTIVE);
         employee2.setPreferredFirstName("Sam");
-        employee2.setLastName("Intern");
-        employee2.setEmail(EmailAddress.valueOf("sam.intern@uscm.org"));
-        employee2.setEmploymentStatus(EmploymentStatus.ACTIVE);
-        entityManager.persist(employee2);
 
         checkSearchByNameOrEmplidFindsEmployee1("Joseph Staff");
         checkSearchByNameOrEmplidFindsEmployee1("Staff, Joseph");
@@ -193,29 +169,9 @@ public class EmployeeDAOImplTest
     @Test
     public void testGetByNameEmailOrEmployeeId_findsCorrectEmployee()
     {
-        EmployeeEntity employee1 = new EmployeeEntity();
-        employee1.setKey(new EmployeeEntity.Key(employeeId1, 0));
-        employee1.setFirstName("Joseph");
-        employee1.setLastName("Staff");
-        employee1.setEmploymentStatus(EmploymentStatus.ACTIVE);
-        entityManager.persist(employee1);
-        
-
-        EmployeeEntity employee2 = new EmployeeEntity();
-        employee2.setKey(new EmployeeEntity.Key(employeeId2, 0));
-        employee2.setFirstName("Samuel");
-        employee2.setLastName("Intern");
-        employee2.setEmail(EmailAddress.valueOf("sam.intern@uscm.org"));
-        employee2.setEmploymentStatus(EmploymentStatus.ACTIVE);
-        entityManager.persist(employee2);
-        
-        EmployeeEntity employee3 = new EmployeeEntity();
-        employee3.setKey(new EmployeeEntity.Key(employeeId3, 0));
-        employee3.setFirstName("Jane");
-        employee3.setLastName("Staff");
-        employee3.setEmail(EmailAddress.valueOf("jane.staff@ccci.org"));
-        employee3.setEmploymentStatus(EmploymentStatus.ACTIVE);
-        entityManager.persist(employee3);
+        createEmployeeWithStatus(employeeId1, "Joseph", "Staff", null, EmploymentStatus.ACTIVE);
+        createEmployeeWithStatus(employeeId2, "Samuel", "Intern", "sam.intern@uscm.org", EmploymentStatus.ACTIVE);
+        createEmployeeWithStatus(employeeId3, "Jane", "Staff", "jane.staff@ccci.org", EmploymentStatus.ACTIVE);
         
         checkGetByNameEmailOrEmployeeIdGetsEmployee(employeeId1.toString(), employeeId1);
         checkGetByNameEmailOrEmployeeIdGetsEmployee(employeeId2.toString(), employeeId2);
@@ -234,19 +190,8 @@ public class EmployeeDAOImplTest
     @Test(expectedExceptions = MultipleEmployeesFoundException.class)
     public void testGetByNameEmailOrEmployeeId_bombsWhenMultipleResults()
     {
-        EmployeeEntity employee1 = new EmployeeEntity();
-        employee1.setKey(new EmployeeEntity.Key(employeeId1, 0));
-        employee1.setFirstName("Joseph");
-        employee1.setLastName("Staff");
-        employee1.setEmploymentStatus(EmploymentStatus.ACTIVE);
-        entityManager.persist(employee1);
-        
-        EmployeeEntity employee3 = new EmployeeEntity();
-        employee3.setKey(new EmployeeEntity.Key(employeeId3, 0));
-        employee3.setFirstName("Jane");
-        employee3.setLastName("Staff");
-        employee3.setEmploymentStatus(EmploymentStatus.ACTIVE);
-        entityManager.persist(employee3);
+        createEmployeeWithStatus(employeeId1, "Joseph", "Staff", null, EmploymentStatus.ACTIVE);
+        createEmployeeWithStatus(employeeId3, "Jane", "Staff", null, EmploymentStatus.ACTIVE);
         
         employeeDAO.getByNameEmailOrEmployeeId("Staff");
     }
@@ -260,22 +205,24 @@ public class EmployeeDAOImplTest
     @Test
     public void testGetPersonalEmailAddressesForIds_straightforward()
     {
-        createEmployeeWithEmail(employeeId1, "Joe", "Staff", "joe.staff@cru.org");
-        createEmployeeWithEmail(employeeId2, "Sam", "Intern", "sam.intern@cru.org");
+        createEmployee(employeeId1, "Joe", "Staff", "joe.staff@cru.org");
+        createEmployee(employeeId2, "Sam", "Intern", "sam.intern@cru.org");
 
         Set<PersonalEmailAddress> emailAddresses = employeeDAO.getPersonalEmailAddressesForIds(
             Sets.newHashSet(employeeId1, employeeId2));
         
         Assert.assertEquals(2, emailAddresses.size());
-        assertContainsEmail(emailAddresses, "joe.staff@cru.org", "Joe Staff", "Expected to find Joe's email address");
-        assertContainsEmail(emailAddresses, "sam.intern@cru.org", "Sam Intern", "Expected to find Sam's email address");
+        assertContainsEmail(emailAddresses, "joe.staff@cru.org", "Joe Staff",
+                "Expected to find Joe's email address");
+        assertContainsEmail(emailAddresses, "sam.intern@cru.org", "Sam Intern",
+                "Expected to find Sam's email address");
     }
     
     @Test
     public void testGetPersonalEmailAddressesForIds_filtersEmptyEmails()
     {
-        createEmployeeWithEmail(employeeId1, "Joe", "Staff", "joe.staff@cru.org");
-        createEmployeeWithoutEmail(employeeId2, "Sam", "Intern"); // No email - should be filtered out
+        createEmployee(employeeId1, "Joe", "Staff", "joe.staff@cru.org");
+        createEmployee(employeeId2, "Sam", "Intern", null); // No email - should be filtered out
 
         Set<PersonalEmailAddress> emailAddresses = employeeDAO.getPersonalEmailAddressesForIds(
             Sets.newHashSet(employeeId1, employeeId2));
@@ -294,28 +241,34 @@ public class EmployeeDAOImplTest
     @Test
     public void testGetPersonalEmailAddressesForIds_chunking()
     {
-        // Create a query-counting DAO for this test
-        QueryCountingEmployeeDAO queryCountingDAO = new QueryCountingEmployeeDAO();
-        queryCountingDAO.psEntityManager = entityManager;
-        queryCountingDAO.setPartitionSize(2);
+        // Set a small partition size to force chunking with our test data
+        employeeDAO.setPartitionSize(2);
         
-        createEmployeeWithEmail(employeeId1, "Joe", "Staff", "joe.staff@cru.org");
-        createEmployeeWithEmail(employeeId2, "Sam", "Intern", "sam.intern@cru.org");
-        createEmployeeWithEmail(employeeId3, "Jane", "Manager", "jane.manager@cru.org");
+        // Test the partitioning logic directly
+        Set<EmployeeId> employeeIds = Sets.newHashSet(employeeId1, employeeId2, employeeId3);
+        List<List<EmployeeId>> partitions = employeeDAO.partition(employeeIds);
+        
+        // Verify that 3 employee IDs with partition size 2 creates exactly 2 partitions
+        Assert.assertEquals("Expected 2 partitions due to chunking", 2, partitions.size());
+        Assert.assertEquals("First partition should have 2 employees", 2, partitions.get(0).size());
+        Assert.assertEquals("Second partition should have 1 employee", 1, partitions.get(1).size());
+        
+        // Test that the actual method still works correctly with chunking
+        createEmployee(employeeId1, "Joe", "Staff", "joe.staff@cru.org");
+        createEmployee(employeeId2, "Sam", "Intern", "sam.intern@cru.org");
+        createEmployee(employeeId3, "Jane", "Manager", "jane.manager@cru.org");
 
-        // This will be split into chunks: [employee1, employee2] and [employee3]
-        Set<PersonalEmailAddress> emailAddresses = queryCountingDAO.getPersonalEmailAddressesForIds(
-            Sets.newHashSet(employeeId1, employeeId2, employeeId3));
+        Set<PersonalEmailAddress> emailAddresses = employeeDAO.getPersonalEmailAddressesForIds(employeeIds);
         
         Assert.assertEquals(3, emailAddresses.size());
         
         // Verify all employees are found despite chunking
-        assertContainsEmail(emailAddresses, "joe.staff@cru.org", "Joe Staff", "Expected to find Joe's email from first chunk");
-        assertContainsEmail(emailAddresses, "sam.intern@cru.org", "Sam Intern", "Expected to find Sam's email from first chunk");
-        assertContainsEmail(emailAddresses, "jane.manager@cru.org", "Jane Manager", "Expected to find Jane's email from second chunk");
-        
-        // Verify that exactly 2 queries were executed (one for each chunk)
-        Assert.assertEquals("Expected 2 queries to be executed due to chunking", 2, queryCountingDAO.getNamedQueryExecutionCount());
+        assertContainsEmail(emailAddresses, "joe.staff@cru.org", "Joe Staff",
+                "Expected to find Joe's email from first chunk");
+        assertContainsEmail(emailAddresses, "sam.intern@cru.org", "Sam Intern",
+                "Expected to find Sam's email from first chunk");
+        assertContainsEmail(emailAddresses, "jane.manager@cru.org", "Jane Manager",
+                "Expected to find Jane's email from second chunk");
     }
     
     @Test(expectedExceptions = NullPointerException.class)
@@ -324,8 +277,8 @@ public class EmployeeDAOImplTest
         employeeDAO.getPersonalEmailAddressesForIds(null);
     }
     
-    // Helper methods for creating test employees
-    private EmployeeEntity createEmployeeWithEmail(EmployeeId employeeId, String firstName, String lastName, String email)
+    // Helper method for creating test employees - no employment status set automatically
+    private EmployeeEntity createEmployee(EmployeeId employeeId, String firstName, String lastName, String email)
     {
         EmployeeEntity employee = new EmployeeEntity();
         employee.setKey(new EmployeeEntity.Key(employeeId, 0));
@@ -337,14 +290,19 @@ public class EmployeeDAOImplTest
         entityManager.persist(employee);
         return employee;
     }
-    
-    private void createEmployeeWithoutEmail(EmployeeId employeeId, String firstName, String lastName)
+
+    // Helper method for creating test employees with specific employment status
+    private EmployeeEntity createEmployeeWithStatus(EmployeeId employeeId, String firstName, String lastName,
+                                                    String email, String employmentStatus)
     {
-        createEmployeeWithEmail(employeeId, firstName, lastName, null);
+        EmployeeEntity employee = createEmployee(employeeId, firstName, lastName, email);
+        employee.setEmploymentStatus(employmentStatus);
+        return employee;
     }
     
     // Helper method for verifying email addresses in results
-    private void assertContainsEmail(Set<PersonalEmailAddress> emailAddresses, String expectedEmail, String expectedName, String description)
+    private void assertContainsEmail(Set<PersonalEmailAddress> emailAddresses, String expectedEmail, String expectedName,
+                                     String description)
     {
         boolean found = false;
         for (PersonalEmailAddress email : emailAddresses) {
@@ -441,68 +399,5 @@ public class EmployeeDAOImplTest
         Assert.assertEquals(employeeId3, couple.getSecondary().getEmployeeId());
         Assert.assertEquals(employeeId1, couple.getHusband().getEmployeeId());
         Assert.assertEquals(employeeId3, couple.getWife().getEmployeeId());
-    }
-    
-    /**
-     * Test helper class that extends EmployeeDAOImpl to count query executions for testing chunking behavior.
-     */
-    private static class QueryCountingEmployeeDAO extends EmployeeDAOImpl {
-        private int namedQueryExecutionCount = 0;
-        
-        public QueryCountingEmployeeDAO() {
-            super();
-        }
-        
-        @Override
-        public Set<PersonalEmailAddress> getPersonalEmailAddressesForIds(Set<EmployeeId> employeeIds) {
-            Preconditions.checkNotNull(employeeIds, "employeeIds is null");
-            if (employeeIds.isEmpty())
-            {
-                return Sets.newHashSet();
-            }
-
-            // Create partitions manually since the method is private
-            List<List<EmployeeId>> partitions = Lists.newArrayList();
-            Iterable<List<EmployeeId>> partitionAsIterable = Iterables.partition(employeeIds, getPartitionSize());
-            for (Iterable<EmployeeId> partAsIterable : partitionAsIterable)
-            {
-                List<EmployeeId> part = Lists.newArrayList(partAsIterable);
-                partitions.add(part);
-            }
-            
-            Set<PersonalEmailAddress> allPersonalEmailAddresses = Sets.newHashSet();
-            
-            // Count each partition as a separate query execution
-            for (List<EmployeeId> partition : partitions)
-            {
-                namedQueryExecutionCount++; // Count the query execution
-                
-                List<Object[]> rawEmailAddresses = Generics.checkObjectArrayList( 
-                    psEntityManager.createNamedQuery("EmployeeEntity.findEmailInfoByEmployeeIds")
-                    .setParameter("employeeIds", partition)
-                    .getResultList(), 
-                    String.class, String.class, String.class);
-
-                for (Object[] row : rawEmailAddresses)
-                {
-                    String personalName = row[0] + " " + row[1];
-                    String emailAddress = (String) row[2];
-                    try
-                    {
-                        allPersonalEmailAddresses.add(PersonalEmailAddress.newPersonalEmailAddress(emailAddress, personalName));
-                    }
-                    catch (IllegalArgumentException e)
-                    {
-                        log.warn(String.format("employee %s has an invalid email address: %s", personalName, emailAddress));
-                    }
-                }
-            }
-            
-            return allPersonalEmailAddresses;
-        }
-        
-        public int getNamedQueryExecutionCount() {
-            return namedQueryExecutionCount;
-        }
     }
 }

--- a/src/test/java/org/ccci/dao/psdb/EmployeeDAOImplTest.java
+++ b/src/test/java/org/ccci/dao/psdb/EmployeeDAOImplTest.java
@@ -235,11 +235,10 @@ public class EmployeeDAOImplTest
     }
     
     /**
-     * Test that the chunking functionality works correctly when partition size exceeds Oracle's 1000-element IN clause limit.
-     * This test specifically addresses the issue that was causing reminder email failures.
+     * Test that the partition method correctly splits employee IDs into chunks based on partition size.
      */
     @Test
-    public void testGetPersonalEmailAddressesForIds_chunking()
+    public void testPartition_chunksCorrectly()
     {
         // Set a small partition size to force chunking with our test data
         employeeDAO.setPartitionSize(2);
@@ -253,7 +252,26 @@ public class EmployeeDAOImplTest
         Assert.assertEquals("First partition should have 2 employees", 2, partitions.get(0).size());
         Assert.assertEquals("Second partition should have 1 employee", 1, partitions.get(1).size());
         
-        // Test that the actual method still works correctly with chunking
+        // Verify all original employee IDs are present in the partitions
+        Set<EmployeeId> allPartitionedIds = Sets.newHashSet();
+        for (List<EmployeeId> partition : partitions) {
+            allPartitionedIds.addAll(partition);
+        }
+        Assert.assertEquals("All employee IDs should be present in partitions", employeeIds, allPartitionedIds);
+    }
+
+    /**
+     * Test that the chunking functionality works correctly for getPersonalEmailAddressesForIds 
+     * when partition size exceeds Oracle's 1000-element IN clause limit.
+     * This test specifically addresses the issue that was causing reminder email failures.
+     */
+    @Test
+    public void testGetPersonalEmailAddressesForIds_chunking()
+    {
+        // Set a small partition size to force chunking with our test data
+        employeeDAO.setPartitionSize(2);
+        
+        Set<EmployeeId> employeeIds = Sets.newHashSet(employeeId1, employeeId2, employeeId3);
         createEmployee(employeeId1, "Joe", "Staff", "joe.staff@cru.org");
         createEmployee(employeeId2, "Sam", "Intern", "sam.intern@cru.org");
         createEmployee(employeeId3, "Jane", "Manager", "jane.manager@cru.org");


### PR DESCRIPTION
[HS Ticket](https://secure.helpscout.net/conversation/3025142799/1418641/)

The reminder emails for etimesheet are failing due to trying to gather greater than 1000 email addresses using an IN clause in the query.

This uses the already existing partition method for `getPersonalEmailAddressesForIds()`.